### PR TITLE
chore(deps): bump zfb to 0.1.0-next.44

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -5,7 +5,7 @@ zudo-doc consumer project built by zfb. Output in `dist/` is served by `zfb dev`
 ## Architecture
 
 - **Framework**: Preact + zfb SSG
-- **Package**: `@takazudo/zfb@0.1.0-next.43` (binary) + `@takazudo/zudo-doc@^0.2.4` (components)
+- **Package**: `@takazudo/zfb@0.1.0-next.44` (binary) + `@takazudo/zudo-doc@^0.2.4` (components)
 - **Port**: 4892 (pinned in `zfb.config.ts`)
 - **Node-free mode**: Zero `.mjs` plugins → no `plugin-host.mjs` spawned
 - **Collections**: single `"docs"` collection at `src/content/docs/`

--- a/app/package.json
+++ b/app/package.json
@@ -13,9 +13,9 @@
   "dependencies": {
     "@shikijs/transformers": "^4.0.0",
     "@takazudo/zdtp": "0.2.0-next.2",
-    "@takazudo/zfb": "0.1.0-next.43",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.43",
-    "@takazudo/zfb-runtime": "0.1.0-next.43",
+    "@takazudo/zfb": "0.1.0-next.44",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.44",
+    "@takazudo/zfb-runtime": "0.1.0-next.44",
     "@takazudo/zudo-doc": "^0.2.4",
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.0",
@@ -29,11 +29,11 @@
     "zod": "^3.24.0"
   },
   "optionalDependencies": {
-    "@takazudo/zfb-darwin-arm64": "0.1.0-next.43",
-    "@takazudo/zfb-darwin-x64": "0.1.0-next.43",
-    "@takazudo/zfb-linux-arm64-gnu": "0.1.0-next.43",
-    "@takazudo/zfb-linux-x64-gnu": "0.1.0-next.43",
-    "@takazudo/zfb-win32-x64-msvc": "0.1.0-next.43"
+    "@takazudo/zfb-darwin-arm64": "0.1.0-next.44",
+    "@takazudo/zfb-darwin-x64": "0.1.0-next.44",
+    "@takazudo/zfb-linux-arm64-gnu": "0.1.0-next.44",
+    "@takazudo/zfb-linux-x64-gnu": "0.1.0-next.44",
+    "@takazudo/zfb-win32-x64-msvc": "0.1.0-next.44"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.0",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -15,17 +15,17 @@ importers:
         specifier: 0.2.0-next.2
         version: 0.2.0-next.2(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.43
-        version: 0.1.0-next.43
+        specifier: 0.1.0-next.44
+        version: 0.1.0-next.44
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.43
-        version: 0.1.0-next.43
+        specifier: 0.1.0-next.44
+        version: 0.1.0-next.44
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.43
-        version: 0.1.0-next.43(@takazudo/zfb@0.1.0-next.43)
+        specifier: 0.1.0-next.44
+        version: 0.1.0-next.44(@takazudo/zfb@0.1.0-next.44)
       '@takazudo/zudo-doc':
         specifier: ^0.2.4
-        version: 0.2.5(@takazudo/zdtp@0.2.0-next.2(preact@10.29.2))(@takazudo/zfb-runtime@0.1.0-next.43(@takazudo/zfb@0.1.0-next.43))(@takazudo/zfb@0.1.0-next.43)(preact@10.29.2)(shiki@4.2.0)
+        version: 0.2.5(@takazudo/zdtp@0.2.0-next.2(preact@10.29.2))(@takazudo/zfb-runtime@0.1.0-next.44(@takazudo/zfb@0.1.0-next.44))(@takazudo/zfb@0.1.0-next.44)(preact@10.29.2)(shiki@4.2.0)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -77,20 +77,20 @@ importers:
         version: 5.9.3
     optionalDependencies:
       '@takazudo/zfb-darwin-arm64':
-        specifier: 0.1.0-next.43
-        version: 0.1.0-next.43
+        specifier: 0.1.0-next.44
+        version: 0.1.0-next.44
       '@takazudo/zfb-darwin-x64':
-        specifier: 0.1.0-next.43
-        version: 0.1.0-next.43
+        specifier: 0.1.0-next.44
+        version: 0.1.0-next.44
       '@takazudo/zfb-linux-arm64-gnu':
-        specifier: 0.1.0-next.43
-        version: 0.1.0-next.43
+        specifier: 0.1.0-next.44
+        version: 0.1.0-next.44
       '@takazudo/zfb-linux-x64-gnu':
-        specifier: 0.1.0-next.43
-        version: 0.1.0-next.43
+        specifier: 0.1.0-next.44
+        version: 0.1.0-next.44
       '@takazudo/zfb-win32-x64-msvc':
-        specifier: 0.1.0-next.43
-        version: 0.1.0-next.43
+        specifier: 0.1.0-next.44
+        version: 0.1.0-next.44
 
 packages:
 
@@ -390,44 +390,44 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.43':
-    resolution: {integrity: sha512-2mOI2fRqGBcFqRvop/yjWNgY6LFI/3/SVssJT9jzsS52ojvrZ/rX06jsnhcF/gLMIXqlsh3lEJh37sAFjI3qbA==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.44':
+    resolution: {integrity: sha512-qH85aARkLElWD04aMKY0laEGii/h6n6zWfAwIAYvP6ZJzfp8OiY2J66FFXG2KelcVmem6RM0heNbTXsCEWPTQQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.43':
-    resolution: {integrity: sha512-FUFEg0n1QVurgE9S1D7lJKI/d/th8zj8e7rB+oL8uUBjbmakw+m/M0Gx2p/EapwDVDFqNJo1kQPRGoXMeQ9gTQ==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.44':
+    resolution: {integrity: sha512-T0LiNS/zvDKRipn5vyam4MvcNWtDXDTn/Ldjt8uTw6xlabxOLlqbMxidR00U5hF1RMVGjzpqEwHK3Rwtf1aU6Q==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.43':
-    resolution: {integrity: sha512-s/w0VYcG76dy2jLWcDAx/bHjoR1CROlutTqqgH0UYtjbouGJwMZU9MULxuDsFDzh/YdwJ5Kv23AcxEfsg16iGQ==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.44':
+    resolution: {integrity: sha512-ccl3j/Ks8JQIr67df0aOG51UBXPYlcADymmuxzrhVKs8f14LsG17ZyTMDQVN+mrRCwq69TXdmmsKCqX0UouYaw==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.43':
-    resolution: {integrity: sha512-XicsRVvYlkSvBaw4iD3eIXfUecfguzce4fLdW8tXm+SVGfu2tZ0mTbgRRHmUVBtF/okbvHadEl6UtSrgIYj95A==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.44':
+    resolution: {integrity: sha512-YlX73IIse50JxdollPVn5vs6pKdKLLlTxJu6D/U8rZmx0HIhx+/z27zywy3vfIuK11bxkGMRxJNT41uHJ6eJuA==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.43':
-    resolution: {integrity: sha512-4szqWGy87nc/S3bV9PX/4IySv8xFqUnaRCteiqRwZbErGRLk3mMAXoWQJfEQWepYmBhyCpAcDHn0d6sW4b15YA==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.44':
+    resolution: {integrity: sha512-WRzAHKBAx9e+SS0x95uaLewgViUhmaH+Q4NgiVjEVMSj6pAc6/6RIhwehRjyN+MnnrVmJHyb6f+oawP//cnCjw==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.43':
-    resolution: {integrity: sha512-7h9Xm+Q8M6GxYOHXSNBey0kpr4VHOnEOiER6E/28jN2R9uHojHQTOk96s6yBtuFblsEEViTLK1uOP0Du2Ooh1Q==}
+  '@takazudo/zfb-runtime@0.1.0-next.44':
+    resolution: {integrity: sha512-sZX9wdAIM54X5LjwuSDFw4VG6VoyQ8GZbiKVyl9O//F7ZyFuuVVF2d3MZCS5J6PxRG/fOm0F6su8atkCZJngTg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.43
+      '@takazudo/zfb': 0.1.0-next.44
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.43':
-    resolution: {integrity: sha512-51cmAmhI/RaAIVz6asZUpne4ZBppsGR0cbj6Itu0Juv6BUy10x9WRCeHT6SSWiZNh6TiYlyOxiQLtLzGA11U/g==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.44':
+    resolution: {integrity: sha512-pZHPxZpFFmBvtZPo75kCQtly9DYtc2/gA6hgXkxhTlhAFlDmOe3IfaYiWDnGBMN0Gv8K/IcbakO0oRsaaEzp4Q==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.43':
-    resolution: {integrity: sha512-5weWigclI6XPRToLNyzEYuUN33mPby6N4wZFnJLqBHSmHeENNFh88miWBw11rZK/PNwJSLkt8D34ENx8ViQtLQ==}
+  '@takazudo/zfb@0.1.0-next.44':
+    resolution: {integrity: sha512-RZ4LyXjCAhZJzuw/NGyNfxXb57QExVwZeY0ngoR2GBssGNLxCDgWG8LRuXaDWAef6ZF0x0FQYwsY8VIDr1t3xQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -1693,40 +1693,40 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.43': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.44': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.43':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.44':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.43':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.44':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.43':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.44':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.43':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.44':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.43(@takazudo/zfb@0.1.0-next.43)':
+  '@takazudo/zfb-runtime@0.1.0-next.44(@takazudo/zfb@0.1.0-next.44)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.43
+      '@takazudo/zfb': 0.1.0-next.44
       hono: 4.12.25
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.43':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.44':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.43':
+  '@takazudo/zfb@0.1.0-next.44':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.43
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.43
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.43
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.43
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.43
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.44
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.44
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.44
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.44
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.44
 
-  '@takazudo/zudo-doc@0.2.5(@takazudo/zdtp@0.2.0-next.2(preact@10.29.2))(@takazudo/zfb-runtime@0.1.0-next.43(@takazudo/zfb@0.1.0-next.43))(@takazudo/zfb@0.1.0-next.43)(preact@10.29.2)(shiki@4.2.0)':
+  '@takazudo/zudo-doc@0.2.5(@takazudo/zdtp@0.2.0-next.2(preact@10.29.2))(@takazudo/zfb-runtime@0.1.0-next.44(@takazudo/zfb@0.1.0-next.44))(@takazudo/zfb@0.1.0-next.44)(preact@10.29.2)(shiki@4.2.0)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.43
-      '@takazudo/zfb-runtime': 0.1.0-next.43(@takazudo/zfb@0.1.0-next.43)
+      '@takazudo/zfb': 0.1.0-next.44
+      '@takazudo/zfb-runtime': 0.1.0-next.44(@takazudo/zfb@0.1.0-next.44)
       gray-matter: 4.0.3
       preact: 10.29.2
     optionalDependencies:


### PR DESCRIPTION
## Summary
Bump the zfb toolchain dependency from `0.1.0-next.43` to `0.1.0-next.44` (current npm `next` dist-tag) across all `@takazudo/zfb*` packages in `app/package.json`.

The `next.43 → next.44` delta upstream is **docs-only** (PR #1043 — embed/esbuild docs + a test-assertion clarification); no functional or breaking changes to the build pipeline.

## Changes
- `app/package.json` — bumped all 8 `@takazudo/zfb*` entries (3 `dependencies` + 5 platform-specific `optionalDependencies`) to `0.1.0-next.44`. `@takazudo/zdtp` (`0.2.0-next.2`) intentionally untouched.
- `app/pnpm-lock.yaml` — regenerated via `pnpm install`; specifiers + resolved versions consistent. `@takazudo/zudo-doc`'s published `^0.1.0-next.43` peerDependency caret ranges left as-is (satisfied by next.44).
- `app/CLAUDE.md` — synced the `@takazudo/zfb@…` version reference to next.44.

## Test Plan
- ✅ `pnpm install` (app/) resolves next.44, native `@takazudo/zfb-darwin-arm64/zfb` binary at next.44
- ✅ `pnpm exec zfb build` (app/) → **235 pages built** (node-free sidecar build). Pre-existing broken-markdown-link warnings only (skill cross-refs; not a regression).
- ✅ CI Rust checks (fmt/clippy/test) — pass
- ✅ Code review (Opus fallback; codex out of credits) — no issues, bump consistent