### PR TITLE
feat(app): lean viewer — drop zdtp, sidebar resizer, live sidebar filter

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@shikijs/transformers": "^4.0.0",
-    "@takazudo/zdtp": "0.2.0-next.2",
     "@takazudo/zfb": "0.1.0-next.44",
     "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.44",
     "@takazudo/zfb-runtime": "0.1.0-next.44",

--- a/app/pages/lib/_body-end-islands.tsx
+++ b/app/pages/lib/_body-end-islands.tsx
@@ -2,12 +2,18 @@
 /** @jsxImportSource preact */
 // Body-end islands for CCResDoc.
 //
-// Minimal set: ClientRouterBootstrap (enables SPA soft-swap navigation).
+// Minimal set: ClientRouterBootstrap (enables SPA soft-swap navigation) plus
+// the optional SidebarResizerInit drag handle (gated on settings.sidebarResizer).
 // No AI chat modal, no design token panel, no image enlarge.
 
 import type { JSX, VNode } from "preact";
 import { Island } from "@takazudo/zfb";
+// SidebarResizerInit is a plain inline <script> (not a hydrated island): it
+// attaches a drag handle to #desktop-sidebar on load and after each route swap.
+// Render it directly — no Island wrapper — mirroring zudo-doc's scaffold.
+import { SidebarResizerInit } from "@takazudo/zudo-doc/sidebar-resizer";
 import ClientRouterBootstrap from "@/components/client-router-bootstrap";
+import { settings } from "@/config/settings";
 
 (ClientRouterBootstrap as { displayName?: string }).displayName =
   "ClientRouterBootstrap";
@@ -18,5 +24,10 @@ export function BodyEndIslands(): JSX.Element {
     children: <ClientRouterBootstrap />,
   }) as unknown as VNode;
 
-  return <>{routerIsland}</>;
+  return (
+    <>
+      {routerIsland}
+      {settings.sidebarResizer && <SidebarResizerInit />}
+    </>
+  );
 }

--- a/app/pages/lib/_head-with-defaults.tsx
+++ b/app/pages/lib/_head-with-defaults.tsx
@@ -5,7 +5,13 @@
 
 import type { JSX } from "preact";
 import { DocHead } from "@takazudo/zudo-doc/head";
-import { ColorSchemeProvider } from "@takazudo/zudo-doc/theme";
+// Import ColorSchemeProvider from the dedicated subpath, NOT the
+// "@takazudo/zudo-doc/theme" barrel — the barrel also re-exports the
+// ColorTweakExportModal / design-token-serde modules, whose types reference
+// the (now removed) @takazudo/zdtp panel and which this SSR-only head does
+// not need in its zfb esbuild graph. Mirrors zudo-doc's own scaffold.
+import ColorSchemeProvider from "@takazudo/zudo-doc/theme/color-scheme-provider";
+import { SIDEBAR_RESIZER_RESTORE_SCRIPT } from "@takazudo/zudo-doc/sidebar-resizer";
 import { settings } from "@/config/settings";
 import { colorSchemeCssText } from "@/config/color-scheme-utils";
 
@@ -32,6 +38,12 @@ export function HeadWithDefaults({
             respectPrefersColorScheme: settings.colorMode.respectPrefersColorScheme,
           }}
         />
+      )}
+      {/* Pre-paint inline script: restore the persisted sidebar width to
+          --zd-sidebar-w on :root before first paint, so a reload after
+          drag-resizing doesn't snap back to the CSS default clamp() width. */}
+      {settings.sidebarResizer && (
+        <script dangerouslySetInnerHTML={{ __html: SIDEBAR_RESIZER_RESTORE_SCRIPT }} />
       )}
       <DocHead
         title={title}

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@shikijs/transformers':
         specifier: ^4.0.0
         version: 4.2.0
-      '@takazudo/zdtp':
-        specifier: 0.2.0-next.2
-        version: 0.2.0-next.2(preact@10.29.2)
       '@takazudo/zfb':
         specifier: 0.1.0-next.44
         version: 0.1.0-next.44
@@ -25,7 +22,7 @@ importers:
         version: 0.1.0-next.44(@takazudo/zfb@0.1.0-next.44)
       '@takazudo/zudo-doc':
         specifier: ^0.2.4
-        version: 0.2.5(@takazudo/zdtp@0.2.0-next.2(preact@10.29.2))(@takazudo/zfb-runtime@0.1.0-next.44(@takazudo/zfb@0.1.0-next.44))(@takazudo/zfb@0.1.0-next.44)(preact@10.29.2)(shiki@4.2.0)
+        version: 0.2.6(@takazudo/zfb-runtime@0.1.0-next.44(@takazudo/zfb@0.1.0-next.44))(@takazudo/zfb@0.1.0-next.44)(preact@10.29.2)(shiki@4.2.0)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -383,13 +380,6 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@takazudo/zdtp@0.2.0-next.2':
-    resolution: {integrity: sha512-NK37TXU+UvLG6SHKwSZOXj+2Nx9knrkVoZsaWL4tUsJMo9XbHVsh5qPVthbaO+M94aCeAD5mSNIhpM5pf2tniw==}
-    engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
-    hasBin: true
-    peerDependencies:
-      preact: ^10.29.1
-
   '@takazudo/zfb-adapter-cloudflare@0.1.0-next.44':
     resolution: {integrity: sha512-qH85aARkLElWD04aMKY0laEGii/h6n6zWfAwIAYvP6ZJzfp8OiY2J66FFXG2KelcVmem6RM0heNbTXsCEWPTQQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
@@ -431,13 +421,13 @@ packages:
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zudo-doc@0.2.5':
-    resolution: {integrity: sha512-tzq7Fk+uNayZgTV6z7O65/TeVa+8eh3sMYtnaXdwjeJ2Z1jFF3ALC3xejTrTQD+YbcVyN12cP4uonOx38O7Ynw==}
+  '@takazudo/zudo-doc@0.2.6':
+    resolution: {integrity: sha512-03iroS7aST+ZRFxw1Mv191njq9sQZH1qBCDG57IloCRbgltZiOROwYH7bkbR+wqoUUeQAc0/jaXe1+NB51fUTA==}
     peerDependencies:
       '@takazudo/zdtp': ^0.2.0-next.2
-      '@takazudo/zfb': ^0.1.0-next.43
-      '@takazudo/zfb-runtime': ^0.1.0-next.43
-      '@takazudo/zudo-doc-history-server': ^0.2.5
+      '@takazudo/zfb': ^0.1.0-next.44
+      '@takazudo/zfb-runtime': ^0.1.0-next.44
+      '@takazudo/zudo-doc-history-server': ^0.2.6
       preact: ^10.29.1
       shiki: ^4.0.2
     peerDependenciesMeta:
@@ -635,10 +625,6 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
-
-  culori@4.0.2:
-    resolution: {integrity: sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cytoscape-cose-bilkent@4.1.0:
     resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
@@ -1688,11 +1674,6 @@ snapshots:
       tailwindcss: 4.3.1
       vite: 8.0.16(@types/node@22.19.21)(jiti@2.7.0)
 
-  '@takazudo/zdtp@0.2.0-next.2(preact@10.29.2)':
-    dependencies:
-      culori: 4.0.2
-      preact: 10.29.2
-
   '@takazudo/zfb-adapter-cloudflare@0.1.0-next.44': {}
 
   '@takazudo/zfb-darwin-arm64@0.1.0-next.44':
@@ -1723,14 +1704,13 @@ snapshots:
       '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.44
       '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.44
 
-  '@takazudo/zudo-doc@0.2.5(@takazudo/zdtp@0.2.0-next.2(preact@10.29.2))(@takazudo/zfb-runtime@0.1.0-next.44(@takazudo/zfb@0.1.0-next.44))(@takazudo/zfb@0.1.0-next.44)(preact@10.29.2)(shiki@4.2.0)':
+  '@takazudo/zudo-doc@0.2.6(@takazudo/zfb-runtime@0.1.0-next.44(@takazudo/zfb@0.1.0-next.44))(@takazudo/zfb@0.1.0-next.44)(preact@10.29.2)(shiki@4.2.0)':
     dependencies:
       '@takazudo/zfb': 0.1.0-next.44
       '@takazudo/zfb-runtime': 0.1.0-next.44(@takazudo/zfb@0.1.0-next.44)
       gray-matter: 4.0.3
       preact: 10.29.2
     optionalDependencies:
-      '@takazudo/zdtp': 0.2.0-next.2(preact@10.29.2)
       shiki: 4.2.0
 
   '@tybys/wasm-util@0.10.2':
@@ -1939,8 +1919,6 @@ snapshots:
       layout-base: 2.0.1
 
   csstype@3.2.3: {}
-
-  culori@4.0.2: {}
 
   cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
     dependencies:

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 0.1.0-next.44(@takazudo/zfb@0.1.0-next.44)
       '@takazudo/zudo-doc':
         specifier: ^0.2.4
-        version: 0.2.6(@takazudo/zfb-runtime@0.1.0-next.44(@takazudo/zfb@0.1.0-next.44))(@takazudo/zfb@0.1.0-next.44)(preact@10.29.2)(shiki@4.2.0)
+        version: 0.2.5(@takazudo/zfb-runtime@0.1.0-next.44(@takazudo/zfb@0.1.0-next.44))(@takazudo/zfb@0.1.0-next.44)(preact@10.29.2)(shiki@4.2.0)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -421,13 +421,13 @@ packages:
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zudo-doc@0.2.6':
-    resolution: {integrity: sha512-03iroS7aST+ZRFxw1Mv191njq9sQZH1qBCDG57IloCRbgltZiOROwYH7bkbR+wqoUUeQAc0/jaXe1+NB51fUTA==}
+  '@takazudo/zudo-doc@0.2.5':
+    resolution: {integrity: sha512-tzq7Fk+uNayZgTV6z7O65/TeVa+8eh3sMYtnaXdwjeJ2Z1jFF3ALC3xejTrTQD+YbcVyN12cP4uonOx38O7Ynw==}
     peerDependencies:
       '@takazudo/zdtp': ^0.2.0-next.2
-      '@takazudo/zfb': ^0.1.0-next.44
-      '@takazudo/zfb-runtime': ^0.1.0-next.44
-      '@takazudo/zudo-doc-history-server': ^0.2.6
+      '@takazudo/zfb': ^0.1.0-next.43
+      '@takazudo/zfb-runtime': ^0.1.0-next.43
+      '@takazudo/zudo-doc-history-server': ^0.2.5
       preact: ^10.29.1
       shiki: ^4.0.2
     peerDependenciesMeta:
@@ -1704,7 +1704,7 @@ snapshots:
       '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.44
       '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.44
 
-  '@takazudo/zudo-doc@0.2.6(@takazudo/zfb-runtime@0.1.0-next.44(@takazudo/zfb@0.1.0-next.44))(@takazudo/zfb@0.1.0-next.44)(preact@10.29.2)(shiki@4.2.0)':
+  '@takazudo/zudo-doc@0.2.5(@takazudo/zfb-runtime@0.1.0-next.44(@takazudo/zfb@0.1.0-next.44))(@takazudo/zfb@0.1.0-next.44)(preact@10.29.2)(shiki@4.2.0)':
     dependencies:
       '@takazudo/zfb': 0.1.0-next.44
       '@takazudo/zfb-runtime': 0.1.0-next.44(@takazudo/zfb@0.1.0-next.44)

--- a/app/src/components/sidebar-tree.tsx
+++ b/app/src/components/sidebar-tree.tsx
@@ -288,7 +288,13 @@ export default function SidebarTree({ nodes, currentSlug, rootMenuItems, backToM
             type="text"
             placeholder={filterPlaceholder}
             value={query}
-            onChange={(e) => setQuery(e.currentTarget.value)}
+            // onInput (not onChange): under zfb's esbuild Preact the filter
+            // input must fire per-keystroke. Preact binds onChange to the native
+            // `change` event (fires on blur) — so onChange makes the filter
+            // blur-only. onInput fires on every keystroke for a live filter.
+            // (The zudo-doc scaffold uses onChange, which only works on its
+            // preact/compat build where onChange === onInput; see upstream report.)
+            onInput={(e) => setQuery(e.currentTarget.value)}
             className="bg-transparent text-small outline-none w-full text-fg placeholder:text-muted"
           />
         </div>

--- a/app/src/config/settings.ts
+++ b/app/src/config/settings.ts
@@ -40,8 +40,9 @@ export const settings = {
     darkScheme: "Default Dark",
     respectPrefersColorScheme: true,
   } as ColorModeConfig | false,
-  // No sidebar resizer (can add later)
-  sidebarResizer: false as boolean,
+  // Sidebar resizer — drag the desktop sidebar's right edge to resize it
+  // (width persisted in localStorage; client-side only, node-free).
+  sidebarResizer: true as boolean,
   // Sidebar toggle for mobile
   sidebarToggle: true as boolean,
   // Simple footer (no link columns, just copyright)

--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -17,8 +17,7 @@
  *
  * The package ships a build-generated safelist at `dist/safelist.css`
  * (zudolab/zudo-doc#1993). Importing it via the module resolver is
- * reliable across all consumer environments — same code path as the
- * existing `@import "@takazudo/zdtp/styles.css"` below.
+ * reliable across all consumer environments.
  *
  * Why not @source the package dist/ glob? The old approach
  * (`@source "../../node_modules/@takazudo/zudo-doc/dist/**"`) was
@@ -768,12 +767,13 @@ pre[class^="syntect-"].word-wrap code {
  * span. The inline hex is the desired token color — this rule must NOT
  * override it (so: NO !important on `color`).
  *
- * Runtime (design-token-tweak panel, when enabled): Shiki re-highlights on
- * demand and emits spans with inline style="--shiki-light:#X;--shiki-dark:#Y"
- * — CSS custom properties only, no `color` declaration — depending on this
- * rule to resolve light-dark(var(--shiki-light), var(--shiki-dark)) to the
- * active theme. Shiki spans have no inline `color`, so the rule applies
- * without needing !important. */
+ * The `.shiki` selectors are retained defensively: a client-side Shiki
+ * re-highlighter (none ships in CCResDoc today) would emit spans with inline
+ * style="--shiki-light:#X;--shiki-dark:#Y" — CSS custom properties only, no
+ * `color` declaration — relying on this rule to resolve
+ * light-dark(var(--shiki-light), var(--shiki-dark)) to the active theme. Such
+ * spans have no inline `color`, so the rule applies without needing
+ * !important. CCResDoc itself highlights via the Syntect build-time path. */
 [data-theme] .shiki,
 [data-theme] .shiki span,
 [data-theme] pre[class^="syntect-"],


### PR DESCRIPTION
## Summary
Slim CCResDoc toward a lean, **node-free** zudo-doc-styled resource viewer. Three changes, one cohesive topic. Stays node-free throughout (`zfb.config.ts` keeps `plugins: []`; content still comes from the Rust sidecar).

### 1. Remove the `@takazudo/zdtp` design-token tweak panel
It was already disabled (`designTokenPanel: false`); this completes the removal:
- Drop `@takazudo/zdtp` from `app/package.json` deps. A fresh `pnpm install` no longer pulls it (it was zudo-doc's auto-installed optional peer) — gone from `node_modules`; the lockfile keeps only zudo-doc's peer-declaration metadata.
- Decouple the code: import `ColorSchemeProvider` from the dedicated `@takazudo/zudo-doc/theme/color-scheme-provider` subpath instead of the `/theme` barrel (which re-exports the design-token modules that type-reference zdtp). Mirrors zudo-doc's own scaffold; keeps zdtp out of the SSR head graph.
- Clean two stale `global.css` comments that referenced the removed panel. (`designTokenPanel: false` stays in `filterHeaderRightItems` — it's a required zudo-doc flag that gates the panel off, not a zdtp import.)

### 2. Enable the sidebar resizer (pure client-side, node-free)
- `settings.sidebarResizer: false → true`
- head: inject `SIDEBAR_RESIZER_RESTORE_SCRIPT` (pre-paint width restore)
- body-end: render `<SidebarResizerInit />` (drag handle on `#desktop-sidebar`)
- both gated on `settings.sidebarResizer`, mirroring zudo-doc's scaffold.

### 3. Fix the sidebar filter so it works live (`onChange → onInput`)
The filter was already present in `src/components/sidebar-tree.tsx` but **blur-only**: it used `onChange`, which under zfb's esbuild-Preact binds to the native `change` event (fires on blur), not per-keystroke. Switched to `onInput` for real-time filtering. Root cause filed upstream: **zudolab/zudo-doc#2135**.

## Scope guard
Evicting zdtp required a clean lockfile regen, which would otherwise float `@takazudo/zudo-doc ^0.2.4` up to the latest `0.2.6`. Pinned the lockfile back to `0.2.5` (matching `main`) so this PR is **not** an incidental zudo-doc bump. `package.json` keeps its `^0.2.4` caret.

## Out of scope (intentionally NOT done)
Search (Node MiniSearch plugin — incompatible with node-free; future Rust-side index), `claudeResources`/`claudeSkills` (the `.mjs` plugin the Rust sidecar already replaces), `docHistory`, `imageEnlarge`, header github-link. Color schemes / dark-default unchanged (already match the target preset).

## Test Plan
- `pnpm exec zfb build` → **235 pages**, node-free ✅
- Code review (3 Opus reviewers) — no blocking issues ✅
- verify-ui (headless, 1280px desktop): ✅
  - Resizer: `#desktop-sidebar` is `position: fixed`, drag handle (`[data-sidebar-resizer]`) attaches, no console errors
  - Filter: typing "commit" narrows 158 → 4 links **live** (no blur); clearing restores; `Cmd/Ctrl+/` focuses the input
- CI Rust checks (unaffected by app/ changes)

## Follow-ups
- agent-found #52 — audit possibly-vestigial `shiki` / `@shikijs/transformers` deps