### PR TITLE
Toolchain Refresh: zfb→next.71, zudo-doc→2.1.1, + CodeBlockEnhancer/TOC/a11y ports

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -5,7 +5,7 @@ zudo-doc consumer project built by zfb. Output in `dist/` is served by `zfb dev`
 ## Architecture
 
 - **Framework**: Preact + zfb SSG
-- **Package**: `@takazudo/zfb@0.1.0-next.53` (binary) + `@takazudo/zudo-doc@^0.2.4` (components)
+- **Package**: `@takazudo/zfb@0.1.0-next.71` (binary) + `@takazudo/zudo-doc@^0.2.4` (components)
 - **Port**: 4892 (pinned in `zfb.config.ts`)
 - **Node-free mode**: Zero `.mjs` plugins → no `plugin-host.mjs` spawned
 - **Collections**: single `"docs"` collection at `src/content/docs/`

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -20,7 +20,9 @@ pnpm install          # once — populates node_modules incl. native zfb binary
 pnpm exec zfb build   # node-free: invokes native binary directly
 ```
 
-**`app/` is a STANDALONE pnpm project with `node-linker=hoisted`** (see `app/.npmrc`),
+**`app/` is a STANDALONE pnpm project with a hoisted node-linker** — set as
+`nodeLinker: hoisted` in `app/pnpm-workspace.yaml` (pnpm 10+/11 no longer reads
+`node-linker` from `app/.npmrc`, which is kept only as a legacy/back-compat marker),
 NOT a workspace member. This is required for the bundled `.app`: the Tauri host
 bundles `app/node_modules` and copies it (dereferencing symlinks) into a writable
 workspace at runtime. pnpm's default isolated `.pnpm` store does not survive that

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -5,7 +5,7 @@ zudo-doc consumer project built by zfb. Output in `dist/` is served by `zfb dev`
 ## Architecture
 
 - **Framework**: Preact + zfb SSG
-- **Package**: `@takazudo/zfb@0.1.0-next.71` (binary) + `@takazudo/zudo-doc@^0.2.4` (components)
+- **Package**: `@takazudo/zfb@0.1.0-next.71` (binary) + `@takazudo/zudo-doc@^2.1.1` (components)
 - **Port**: 4892 (pinned in `zfb.config.ts`)
 - **Node-free mode**: Zero `.mjs` plugins → no `plugin-host.mjs` spawned
 - **Collections**: single `"docs"` collection at `src/content/docs/`

--- a/app/dist/placeholder.txt
+++ b/app/dist/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder so the Tauri bundle.resources glob (../app/dist/**/*) matches before a real zfb build populates this dir. Real dist output is gitignored; this file is the gitignore exception (!app/dist/placeholder.txt).

--- a/app/dist/placeholder.txt
+++ b/app/dist/placeholder.txt
@@ -1,1 +1,0 @@
-Placeholder so the Tauri bundle.resources glob (../app/dist/**/*) matches before a real zfb build populates this dir. Real dist output is gitignored; this file is the gitignore exception (!app/dist/placeholder.txt).

--- a/app/package.json
+++ b/app/package.json
@@ -11,9 +11,9 @@
     "zfb": "zfb"
   },
   "dependencies": {
-    "@takazudo/zfb": "0.1.0-next.53",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.53",
-    "@takazudo/zfb-runtime": "0.1.0-next.53",
+    "@takazudo/zfb": "0.1.0-next.71",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.71",
+    "@takazudo/zfb-runtime": "0.1.0-next.71",
     "@takazudo/zudo-doc": "^0.2.4",
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.0",
@@ -26,11 +26,11 @@
     "zod": "^3.24.0"
   },
   "optionalDependencies": {
-    "@takazudo/zfb-darwin-arm64": "0.1.0-next.53",
-    "@takazudo/zfb-darwin-x64": "0.1.0-next.53",
-    "@takazudo/zfb-linux-arm64-gnu": "0.1.0-next.53",
-    "@takazudo/zfb-linux-x64-gnu": "0.1.0-next.53",
-    "@takazudo/zfb-win32-x64-msvc": "0.1.0-next.53"
+    "@takazudo/zfb-darwin-arm64": "0.1.0-next.71",
+    "@takazudo/zfb-darwin-x64": "0.1.0-next.71",
+    "@takazudo/zfb-linux-arm64-gnu": "0.1.0-next.71",
+    "@takazudo/zfb-linux-x64-gnu": "0.1.0-next.71",
+    "@takazudo/zfb-win32-x64-msvc": "0.1.0-next.71"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.0",

--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,7 @@
     "@takazudo/zfb": "0.1.0-next.71",
     "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.71",
     "@takazudo/zfb-runtime": "0.1.0-next.71",
-    "@takazudo/zudo-doc": "^0.2.4",
+    "@takazudo/zudo-doc": "^2.1.1",
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.0",
     "katex": "^0.16.38",

--- a/app/pages/docs/[[...slug]].tsx
+++ b/app/pages/docs/[[...slug]].tsx
@@ -22,6 +22,8 @@ import { BodyEndIslands } from "../lib/_body-end-islands";
 import { composeMetaTitle } from "../lib/_compose-meta-title";
 import { toSlugParams } from "@/utils/slug";
 import { settings } from "@/config/settings";
+import { extractHeadings } from "@takazudo/zudo-doc/extract-headings";
+import type { HeadingItem } from "@takazudo/zudo-doc/extract-headings";
 
 // ---------------------------------------------------------------------------
 // Props contract
@@ -34,6 +36,10 @@ interface DocPageProps {
   navSection?: string;
   hideSidebar?: boolean;
   hideToc?: boolean;
+  /** TOC headings extracted from the entry body. Passed to DocLayoutWithDefaults so
+   *  its built-in Toc/MobileToc render the item list. Pages with hide_toc: true
+   *  still carry headings — the layout suppresses them via hideToc. */
+  headings: readonly HeadingItem[];
   // MDX render function for this entry. zfb does NOT auto-inject `Content` for a
   // programmatic catch-all route (only for MDX-backed page modules), so paths()
   // wires it explicitly from the collection entry — mirrors zudo-doc's scaffold
@@ -92,6 +98,11 @@ export function paths(): Array<{
       const slug = entry.id;
       const slugParams = toSlugParams(slug);
       const navSection = detectNavSection(slug);
+      // Extract TOC headings from the raw body using the project's heading-ID
+      // strategy ("flat") so anchor hrefs in the TOC match rendered heading ids.
+      const headings = extractHeadings(entry.body ?? "", {
+        strategy: settings.headingIdStrategy,
+      });
       const props: DocPageProps & { params: { slug: string[] } } = {
         slug,
         title: entry.data.title,
@@ -99,6 +110,7 @@ export function paths(): Array<{
         navSection,
         hideSidebar: entry.data.hide_sidebar ?? false,
         hideToc: entry.data.hide_toc ?? false,
+        headings,
         Content: entry.Content as DocPageProps["Content"],
         params: { slug: slugParams },
       };
@@ -121,6 +133,7 @@ export default function DocsPage({
   navSection,
   hideSidebar,
   hideToc,
+  headings,
   Content,
 }: PageProps): JSX.Element {
   const metaTitle = composeMetaTitle(title);
@@ -152,6 +165,7 @@ export default function DocsPage({
       }
       hideSidebar={hideSidebar}
       hideToc={hideToc}
+      headings={headings}
       footerOverride={<FooterWithDefaults />}
       bodyEndComponents={<BodyEndIslands />}
     >

--- a/app/pages/lib/_body-end-islands.tsx
+++ b/app/pages/lib/_body-end-islands.tsx
@@ -3,7 +3,8 @@
 // Body-end islands for CCResDoc.
 //
 // Minimal set: ClientRouterBootstrap (enables SPA soft-swap navigation) plus
-// the optional SidebarResizerInit drag handle (gated on settings.sidebarResizer).
+// CodeBlockEnhancer (copy + word-wrap buttons on code blocks) plus the optional
+// SidebarResizerInit drag handle (gated on settings.sidebarResizer).
 // No AI chat modal, no design token panel, no image enlarge.
 
 import type { JSX, VNode } from "preact";
@@ -12,6 +13,11 @@ import { Island } from "@takazudo/zfb";
 // attaches a drag handle to #desktop-sidebar on load and after each route swap.
 // Render it directly — no Island wrapper — mirroring zudo-doc's scaffold.
 import { SidebarResizerInit } from "@takazudo/zudo-doc/sidebar-resizer";
+// CodeBlockEnhancer is a plain inline <script> (not a hydrated island): it wraps
+// <pre class="syntect-*"> elements in .code-block-wrapper and adds copy +
+// word-wrap buttons, wiring zfb navigation events for SPA re-init.
+// Render it directly — no Island wrapper — same pattern as SidebarResizerInit.
+import { CodeBlockEnhancer } from "@takazudo/zudo-doc/code-syntax";
 import ClientRouterBootstrap from "@/components/client-router-bootstrap";
 import { settings } from "@/config/settings";
 
@@ -27,6 +33,7 @@ export function BodyEndIslands(): JSX.Element {
   return (
     <>
       {routerIsland}
+      <CodeBlockEnhancer />
       {settings.sidebarResizer && <SidebarResizerInit />}
     </>
   );

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 0.1.0-next.71
         version: 0.1.0-next.71(@takazudo/zfb@0.1.0-next.71)
       '@takazudo/zudo-doc':
-        specifier: ^0.2.4
-        version: 0.2.5(@takazudo/zfb-runtime@0.1.0-next.71(@takazudo/zfb@0.1.0-next.71))(@takazudo/zfb@0.1.0-next.71)(preact@10.29.2)(shiki@4.2.0)
+        specifier: ^2.1.1
+        version: 2.1.1(@takazudo/zfb-runtime@0.1.0-next.71(@takazudo/zfb@0.1.0-next.71))(@takazudo/zfb@0.1.0-next.71)(katex@0.16.47)(preact@10.29.2)(shiki@4.2.0)(zod@3.25.76)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -420,19 +420,27 @@ packages:
       react:
         optional: true
 
-  '@takazudo/zudo-doc@0.2.5':
-    resolution: {integrity: sha512-tzq7Fk+uNayZgTV6z7O65/TeVa+8eh3sMYtnaXdwjeJ2Z1jFF3ALC3xejTrTQD+YbcVyN12cP4uonOx38O7Ynw==}
+  '@takazudo/zudo-doc@2.1.1':
+    resolution: {integrity: sha512-/Kbr/ZLwuqBhsuoTb/iqtBDKgRzZ1kDTGJAsSttpw/FDKBi6H03b9x1vf0U7nhIwzkuszOX2ceXBYm72KIjdEw==}
+    hasBin: true
     peerDependencies:
-      '@takazudo/zdtp': ^0.2.0-next.2
-      '@takazudo/zfb': ^0.1.0-next.43
-      '@takazudo/zfb-runtime': ^0.1.0-next.43
-      '@takazudo/zudo-doc-history-server': ^0.2.5
+      '@takazudo/zdtp': ^0.4.1
+      '@takazudo/zfb': ^0.1.0-next.71
+      '@takazudo/zfb-runtime': ^0.1.0-next.71
+      '@takazudo/zudo-doc-history-server': ^2.1.0
+      diff: ^8.0.0
+      katex: ^0.16.0
       preact: ^10.29.1
       shiki: ^4.0.2
+      zod: ^4.3.6
     peerDependenciesMeta:
       '@takazudo/zdtp':
         optional: true
       '@takazudo/zudo-doc-history-server':
+        optional: true
+      diff:
+        optional: true
+      katex:
         optional: true
       shiki:
         optional: true
@@ -847,6 +855,10 @@ packages:
       picomatch:
         optional: true
 
+  fs-extra@11.3.5:
+    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
+    engines: {node: '>=14.14'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -949,6 +961,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
@@ -1376,6 +1391,10 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
@@ -1706,13 +1725,18 @@ snapshots:
       '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.71
       '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.71
 
-  '@takazudo/zudo-doc@0.2.5(@takazudo/zfb-runtime@0.1.0-next.71(@takazudo/zfb@0.1.0-next.71))(@takazudo/zfb@0.1.0-next.71)(preact@10.29.2)(shiki@4.2.0)':
+  '@takazudo/zudo-doc@2.1.1(@takazudo/zfb-runtime@0.1.0-next.71(@takazudo/zfb@0.1.0-next.71))(@takazudo/zfb@0.1.0-next.71)(katex@0.16.47)(preact@10.29.2)(shiki@4.2.0)(zod@3.25.76)':
     dependencies:
       '@takazudo/zfb': 0.1.0-next.71
       '@takazudo/zfb-runtime': 0.1.0-next.71(@takazudo/zfb@0.1.0-next.71)
+      fs-extra: 11.3.5
       gray-matter: 4.0.3
+      minimist: 1.2.8
+      picocolors: 1.1.1
       preact: 10.29.2
+      zod: 3.25.76
     optionalDependencies:
+      katex: 0.16.47
       shiki: 4.2.0
 
   '@tybys/wasm-util@0.10.2':
@@ -2158,6 +2182,12 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fs-extra@11.3.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
   fsevents@2.3.3:
     optional: true
 
@@ -2249,6 +2279,12 @@ snapshots:
       esprima: 4.0.1
 
   json-schema-traverse@1.0.0: {}
+
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
 
   katex@0.16.47:
     dependencies:
@@ -2813,6 +2849,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  universalify@2.0.1: {}
 
   uuid@14.0.0: {}
 

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -9,17 +9,17 @@ importers:
   .:
     dependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.53
-        version: 0.1.0-next.53
+        specifier: 0.1.0-next.71
+        version: 0.1.0-next.71
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.53
-        version: 0.1.0-next.53
+        specifier: 0.1.0-next.71
+        version: 0.1.0-next.71
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.53
-        version: 0.1.0-next.53(@takazudo/zfb@0.1.0-next.53)
+        specifier: 0.1.0-next.71
+        version: 0.1.0-next.71(@takazudo/zfb@0.1.0-next.71)
       '@takazudo/zudo-doc':
         specifier: ^0.2.4
-        version: 0.2.5(@takazudo/zfb-runtime@0.1.0-next.53(@takazudo/zfb@0.1.0-next.53))(@takazudo/zfb@0.1.0-next.53)(preact@10.29.2)(shiki@4.2.0)
+        version: 0.2.5(@takazudo/zfb-runtime@0.1.0-next.71(@takazudo/zfb@0.1.0-next.71))(@takazudo/zfb@0.1.0-next.71)(preact@10.29.2)(shiki@4.2.0)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -68,20 +68,20 @@ importers:
         version: 5.9.3
     optionalDependencies:
       '@takazudo/zfb-darwin-arm64':
-        specifier: 0.1.0-next.53
-        version: 0.1.0-next.53
+        specifier: 0.1.0-next.71
+        version: 0.1.0-next.71
       '@takazudo/zfb-darwin-x64':
-        specifier: 0.1.0-next.53
-        version: 0.1.0-next.53
+        specifier: 0.1.0-next.71
+        version: 0.1.0-next.71
       '@takazudo/zfb-linux-arm64-gnu':
-        specifier: 0.1.0-next.53
-        version: 0.1.0-next.53
+        specifier: 0.1.0-next.71
+        version: 0.1.0-next.71
       '@takazudo/zfb-linux-x64-gnu':
-        specifier: 0.1.0-next.53
-        version: 0.1.0-next.53
+        specifier: 0.1.0-next.71
+        version: 0.1.0-next.71
       '@takazudo/zfb-win32-x64-msvc':
-        specifier: 0.1.0-next.53
-        version: 0.1.0-next.53
+        specifier: 0.1.0-next.71
+        version: 0.1.0-next.71
 
 packages:
 
@@ -370,46 +370,55 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.53':
-    resolution: {integrity: sha512-OCcil6XTYLQgO/8djT3WvLPzhgm2FbA1RT9vYePFIKTnz8BNx61oxiCUWrkWmwX8ac6K5f3rQL5xpsXTQR3CzQ==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.71':
+    resolution: {integrity: sha512-NLWkcNQKk43vBlgOYtm9nPb7UlCdIElT6jb+Qm+Q15KxjWKShgumyESjFVrncL/c78LZQ3nU9fm79ERuAUpyMw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.53':
-    resolution: {integrity: sha512-UZMEukrgfHeQ5+y14xrXXAPOAq6QI1LI6y+dNxPNmmZSJIjrzRAFU0TjPAQiltl2ZdUsszv17udqc2scemc4lA==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.71':
+    resolution: {integrity: sha512-+qv+Do28yrS/ON8EMABivS/0meFI7JaumBhGtzmllW8Vx/8LjwYDOyWeqRriA1TnF9dHjz9bt/13mSYZ/PPZjA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.53':
-    resolution: {integrity: sha512-2HUkqqs+XrJLLw18OCv7Ky6EEXegIOhd7R8Xrqr8w+GbVv6Nw4TxHLLhjb9Qr97FlwMJ9mVewPYlBLYiDJjTqw==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.71':
+    resolution: {integrity: sha512-gIzznh56SX2MyuIgdARx7ynJFjoY1pluItt0RsZr4f36gnb3/FpN2Q+0mMVXbLL/gZEZUbyrzOuDOaHnX5H0jA==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.53':
-    resolution: {integrity: sha512-RixlNp1m7DBGqq9PWGMYtxmgg3GIbvYeI13zzMGez47UMRSpglH93Gg3LgSwpBs5c8oaPgLFQHn3pDDJDN9yog==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.71':
+    resolution: {integrity: sha512-F+MR0yQju0931TXyK8OHoZFsskjeFMxethqmPsWV5NHZCh+RidopImRckqozszj0Qy2Zsy03BcNzbvhQYesm6Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.53':
-    resolution: {integrity: sha512-xyCvdL97WkhdBwxIagVq/xZuAzCaypwNUNDaQ7itxq/tfbBt2oyVv5H7vcEW/oG0RXRTFJMABJH2G+Y/9VZkbQ==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.71':
+    resolution: {integrity: sha512-pMeRRScJsuovlvhgn5I9aGH0L8cKEtj8CtWShcb9EXZaQCsNeIjRB445h1OvL8XZdS0mbxG8qzVvqT4ZRQsrKg==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.53':
-    resolution: {integrity: sha512-5i7+VjHr8P0o1R9fnCmU/mp6fadg1CZm42GqH9njomwAj+41pz1MQ+T0iQru8PCiTtLG9B+Inbv/dXdGTKWvLA==}
+  '@takazudo/zfb-runtime@0.1.0-next.71':
+    resolution: {integrity: sha512-s6DQLHzZszIeNTFNeIlQAbMC1s17RXM8Xd51O9QCyhUsCoC2oNAbBUd2LwTR6vztnXDZTIBp6IjkqeNLXXFG2A==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.53
+      '@takazudo/zfb': 0.1.0-next.71
+      react: ^19.2.3
+    peerDependenciesMeta:
+      react:
+        optional: true
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.53':
-    resolution: {integrity: sha512-F3AgrTycPsA9/eQm8E141EvWkc+oBaDwI4m1H/kGfuwQJiX8vcrFqZTLy33FfYKxfKqA3TLaRu4rwoO7t2g6vA==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.71':
+    resolution: {integrity: sha512-IW/UM7BPtc/29c4l+kHdAsmQs5qN/V3LUhsWXkdwG6zxWF8HlHsiEug7SuU9iJSW1gKoVb4Zh8t60AE/EbBFIQ==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.53':
-    resolution: {integrity: sha512-iwed5oRyMWyvE6VB6H0jE6qyIQ24R1M4uUzIeN38VJf1xqKJiCglNwP1J8dduhDEX0F1jtsWrBexfHxnp6K/vw==}
+  '@takazudo/zfb@0.1.0-next.71':
+    resolution: {integrity: sha512-fJyYTLtvh8vIo95qIO+bXcACWVPyeeLJ8Hj2trL2xFLZeY36H1xNmg9PgtYa4z0g5LazSE7EBaB4P/03nsA1bw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
+    peerDependencies:
+      react: ^19.2.3
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   '@takazudo/zudo-doc@0.2.5':
     resolution: {integrity: sha512-tzq7Fk+uNayZgTV6z7O65/TeVa+8eh3sMYtnaXdwjeJ2Z1jFF3ALC3xejTrTQD+YbcVyN12cP4uonOx38O7Ynw==}
@@ -1667,40 +1676,40 @@ snapshots:
       tailwindcss: 4.3.1
       vite: 8.0.16(@types/node@22.19.21)(jiti@2.7.0)
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.53': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.71': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.53':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.71':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.53':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.71':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.53':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.71':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.53':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.71':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.53(@takazudo/zfb@0.1.0-next.53)':
+  '@takazudo/zfb-runtime@0.1.0-next.71(@takazudo/zfb@0.1.0-next.71)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.53
+      '@takazudo/zfb': 0.1.0-next.71
       hono: 4.12.25
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.53':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.71':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.53':
+  '@takazudo/zfb@0.1.0-next.71':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.53
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.53
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.53
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.53
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.53
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.71
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.71
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.71
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.71
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.71
 
-  '@takazudo/zudo-doc@0.2.5(@takazudo/zfb-runtime@0.1.0-next.53(@takazudo/zfb@0.1.0-next.53))(@takazudo/zfb@0.1.0-next.53)(preact@10.29.2)(shiki@4.2.0)':
+  '@takazudo/zudo-doc@0.2.5(@takazudo/zfb-runtime@0.1.0-next.71(@takazudo/zfb@0.1.0-next.71))(@takazudo/zfb@0.1.0-next.71)(preact@10.29.2)(shiki@4.2.0)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.53
-      '@takazudo/zfb-runtime': 0.1.0-next.53(@takazudo/zfb@0.1.0-next.53)
+      '@takazudo/zfb': 0.1.0-next.71
+      '@takazudo/zfb-runtime': 0.1.0-next.71(@takazudo/zfb@0.1.0-next.71)
       gray-matter: 4.0.3
       preact: 10.29.2
     optionalDependencies:

--- a/app/pnpm-workspace.yaml
+++ b/app/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+minimumReleaseAgeExclude:
+  - '@takazudo/zfb-adapter-cloudflare@0.1.0-next.71'
+  - '@takazudo/zfb-darwin-arm64@0.1.0-next.71'
+  - '@takazudo/zfb-darwin-x64@0.1.0-next.71'
+  - '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.71'
+  - '@takazudo/zfb-linux-x64-gnu@0.1.0-next.71'
+  - '@takazudo/zfb-runtime@0.1.0-next.71'
+  - '@takazudo/zfb-win32-x64-msvc@0.1.0-next.71'
+  - '@takazudo/zfb@0.1.0-next.71'

--- a/app/pnpm-workspace.yaml
+++ b/app/pnpm-workspace.yaml
@@ -1,3 +1,17 @@
+# pnpm 10+/11 moved several settings out of .npmrc into this file.
+#
+# nodeLinker: hoisted — REQUIRED for the bundled CcResDoc.app (same reason as the
+# legacy app/.npmrc `node-linker=hoisted`, which pnpm 11 no longer reads). The Tauri
+# host bundles app/node_modules and copies it dereferencing symlinks; pnpm's default
+# isolated `.pnpm` store does not survive that copy — transitive deps like `hono`
+# (via @takazudo/zfb-runtime) become unresolvable and every content page 404s. A flat
+# hoisted node_modules copies cleanly. Keep this in lockstep with app/.npmrc.
+nodeLinker: hoisted
+
+# minimumReleaseAgeExclude — pnpm's supply-chain minimum-release-age gate blocks
+# freshly-published versions; the @takazudo/zfb* prereleases are published and adopted
+# immediately, so they must be excluded from the age check. Bump these together with
+# the zfb pin in package.json.
 minimumReleaseAgeExclude:
   - '@takazudo/zfb-adapter-cloudflare@0.1.0-next.71'
   - '@takazudo/zfb-darwin-arm64@0.1.0-next.71'

--- a/app/pnpm-workspace.yaml
+++ b/app/pnpm-workspace.yaml
@@ -21,3 +21,4 @@ minimumReleaseAgeExclude:
   - '@takazudo/zfb-runtime@0.1.0-next.71'
   - '@takazudo/zfb-win32-x64-msvc@0.1.0-next.71'
   - '@takazudo/zfb@0.1.0-next.71'
+  - '@takazudo/zudo-doc@2.1.1'

--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -209,6 +209,12 @@
   --leading-normal: 1.5;
   --leading-relaxed: 1.625;
 
+  /* Letter-spacing scale (4 steps) — referenced as fallbacks by upstream content CSS */
+  --tracking-tight: -0.025em;
+  --tracking-normal: normal;
+  --tracking-wide: 0.05em;
+  --tracking-wider: 0.1em;
+
   /* ========================================
    * Border radius (3 steps)
    * ======================================== */
@@ -263,6 +269,10 @@ body {
   }
   button {
     cursor: pointer;
+  }
+  :focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
   }
 }
 

--- a/app/zfb-shim.d.ts
+++ b/app/zfb-shim.d.ts
@@ -48,6 +48,7 @@ declare module "zfb/config" {
   }
 
   export interface ZfbConfig {
+    presets?: Partial<ZfbConfig>[];
     outDir?: string;
     publicDir?: string;
     host?: string;


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/ccresdoc/issues/79

---

## Summary

Brings ccresdoc's frontend toolchain current and ports the genuinely-useful upstream improvements (epic #79).

### Dependency bumps
- **`@takazudo/zfb` family `0.1.0-next.53` → `0.1.0-next.71`** (8 pins, lockstep) — #80. Version-bump-only; no consumer API changes.
- **`@takazudo/zudo-doc` `^0.2.4` (0.2.5) → `^2.1.1`** (major jump) — #81. All 14 subpath imports survived with zero edits; kept `zod ^3` (benign unmet-peer warning — zudo-doc's zod code is in subpaths ccresdoc never imports).

### Bundled-`.app` fix (caught during the bump)
- pnpm 11 **ignores `node-linker` in `.npmrc`**, which silently reverted `app/node_modules` to the isolated `.pnpm` layout (`hono` et al. missing at top level) — that breaks the bundled `.app` (Tauri dereferences symlinks → renderer 404s). Added **`nodeLinker: hoisted` to `app/pnpm-workspace.yaml`** and documented it. Hoisted flat layout re-verified (real top-level dirs).

### Useful ports from zudo-doc
- **CodeBlockEnhancer** (#83) — fixes dead copy/word-wrap button CSS by rendering `<CodeBlockEnhancer />` as an inline body-end script (not a hydrated island).
- **`--tracking-*` letter-spacing scale + global `:focus-visible`** (#83) — a11y/correctness tokens.
- **Table of contents** (#84) — `extractHeadings` → `headings` prop on `DocLayoutWithDefaults` (its built-in Toc/MobileToc render; home/404 use `hideToc`).

Deferred per "don't take care of zudo-doc too much": package-CSS adoption, `--zdc-*` rebrand tokens, breadcrumb/versioning/edit-link.

## Verification
- `scripts/run-b4push.sh` green: zfb-pin parity, `cargo fmt`/`clippy`/`test` (incl. live generator + watcher), `pnpm install` + `zfb build`.
- Integration smoke on `base/toolchain-refresh`: `zfb dev` on **4892** serves `GET /` (200) and a real generated page `GET /docs/claude-md/global/` (200); **node-free confirmed** (process tree under the dev PID is only the native `zfb` binary — no `node`/`plugin-host.mjs`); generator emits the full `claude*/` tree.
- Server-side render check: TOC renders (`aria-label="Table of contents"`, 30 anchors), CodeBlockEnhancer script present, `:focus-visible` + `--tracking-*` in served CSS.

## Note on the automated review
The codex review flagged a P1 ("`pnpm exec zfb build` fails — esbuild binary not found"). **Verified false positive**: a clean-room `rm -rf node_modules && pnpm install && pnpm exec zfb build` succeeds ("✓ 2 pages built"). The error path `crates/zfb/binaries/esbuild/esbuild` is zfb's fallback slot used only when `node_modules` isn't installed — i.e. the read-only review sandbox skipped `pnpm install`. The documented build works from a clean install.

## Sub-issues
Closes #80, #81, #82, #83, #84 (merged into this base branch).